### PR TITLE
feat(bangs): add support for custom aliases for bang commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,40 @@ ChatGPT:
   category: 'AI'
 ```
 
+### Aliases
+
+Aliases allow you to create custom shortcuts for single bangs or multi-bang combinations. They are defined in the `aliases` section of your `bangs.yaml` file.
+
+**Example with aliases:**
+
+```yaml
+# Aliases - Custom shortcuts for bangs
+aliases:
+  def: 'ai+g'        # !def -> AI search + Google
+  search: 'g'        # !search -> Google only  
+  shop: 'a+eb'       # !shop -> Amazon + eBay
+
+# Regular bang definitions...
+Google:
+  bang: "g"
+  url: "https://www.google.com/search?q={}"
+  description: 'Popular global search engine'
+  category: 'Search'
+
+Amazon:
+  bang: "a"
+  url: "https://www.amazon.com/s?k={}"
+  description: 'E-commerce platform'
+  category: 'Shopping'
+```
+
+**Usage examples:**
+- `!def machine learning` → Opens both ChatGPT and Google with "machine learning"
+- `!search python` → Opens Google with "python"
+- `!shop laptop` → Opens both Amazon and eBay with "laptop"
+
+Aliases are displayed in the web UI with a special "Aliases" category and purple styling to distinguish them from regular bangs.
+
 ### Default Configuration Options
 
 - **URL**: `default: 'https://www.google.com/search?q={}'` - URL with `{}` placeholder

--- a/bangs.yaml
+++ b/bangs.yaml
@@ -12,6 +12,14 @@ default: 'g'
 # default: 'g+gh+so'     # Google + GitHub + StackOverflow
 # default: 'ddg'         # Just DuckDuckGo
 
+# ================================================================================
+# Aliases - Custom shortcuts for single bangs or multi-bang combinations
+# ================================================================================
+aliases:
+  def: 'ai+g'        # Default search: AI + Google
+  search: 'g'        # Simple search alias for Google
+  shop: 'a+eb'       # Shopping: Amazon + eBay
+
 # ================================================================================ 
 # Search Engines
 # ================================================================================ 

--- a/pkg/bangs/handlers.go
+++ b/pkg/bangs/handlers.go
@@ -36,7 +36,15 @@ func Handler(doAllowNoBang bool, doAllowMultiBang bool, ignoreCharPar string) ht
 }
 
 func listAll(w http.ResponseWriter, r *http.Request) {
-	asJSON, err := json.Marshal(All().Entries)
+	response := struct {
+		Bangs   map[string]Entry  `json:"bangs"`
+		Aliases map[string]string `json:"aliases"`
+	}{
+		Bangs:   All().Entries,
+		Aliases: registry.Aliases,
+	}
+
+	asJSON, err := json.Marshal(response)
 	if err != nil {
 		slog.Error("Error converting registry to json", "err", err)
 		http.Error(w, fmt.Sprintf("Internal JSON error -.-\n%v\n", err), http.StatusInternalServerError)


### PR DESCRIPTION
Introduce an aliases feature that allows users to define custom shortcuts mapping to single or multi-bang combinations in the configuration. This enhancement provides more flexible and user-friendly bang usage by enabling named aliases that represent frequently used bang sequences. The change includes YAML schema updates, backend support for resolving aliases transparently during bang input parsing, and frontend UI enhancements to display aliases as a distinct category with specialized styling and interaction behavior. This improves discoverability and usability of bangs by allowing personalized shorthand commands without altering existing bang functionality.